### PR TITLE
Show events for users who's membership in org is private

### DIFF
--- a/lib/githubApi.js
+++ b/lib/githubApi.js
@@ -23,7 +23,7 @@ function makeRequest(url, accessToken) {
 var apiUrls = {
 	root: 'https://api.github.com',
 	user: 'user',
-	orgs: 'users/%s/orgs',
+	orgs: 'user/orgs',
 	userEvents: 'users/%s/events',
 	userReceivedEvents: 'users/%s/received_events',
 	orgEvents: 'users/%s/events/orgs/%s', // users/:user/events/orgs/:org
@@ -35,7 +35,7 @@ module.exports = {
 		return makeRequest(url.resolve(apiUrls.root, apiUrls.user), token);
 	},
 	organizations: function (user, token) {
-		return makeRequest(url.resolve(apiUrls.root, util.format(apiUrls.orgs, user.login)), token);
+		return makeRequest(url.resolve(apiUrls.root, apiUrls.orgs), token);
 	},
 	userEvents: function (user, token) {
 		return makeRequest(url.resolve(apiUrls.root, util.format(apiUrls.userEvents, user.login)), token);


### PR DESCRIPTION
The GET /users/:username/orgs API only lists public organization membership, but GET /user/orgs lists public and private membership.
https://developer.github.com/v3/orgs/#list-user-organizations
Fixes #7